### PR TITLE
Support for authority TFP format to work with iOS

### DIFF
--- a/ios/Classes/B2CProvider.swift
+++ b/ios/Classes/B2CProvider.swift
@@ -308,13 +308,13 @@ class B2CProvider {
     private func setHostAndTenantFromAuthority(tag: String, authority: MSALAuthority) {
         let parts = authority.url.absoluteString.split(usingRegex: "https://|/")
         hostName = parts[1]
-        tenantName = parts[2]
+        tenantName = parts[3]
         print("B2CProvider [\(tag)] host: \(hostName ?? "nil"), tenant: \(tenantName ?? "nil")")
     }
     
     private func getAuthorityFromPolicyName(tag: String, policyName: String, source: String) -> MSALB2CAuthority? {
         do {
-            let urlString = "https://\(hostName!)/\(tenantName!)/\(policyName)/"
+            let urlString = "https://\(hostName!)/tfp/\(tenantName!)/\(policyName)/"
             let authorityURL = URL(string: urlString)!
             return try MSALB2CAuthority(url: authorityURL)
         }

--- a/ios/Classes/B2CProvider.swift
+++ b/ios/Classes/B2CProvider.swift
@@ -308,7 +308,11 @@ class B2CProvider {
     private func setHostAndTenantFromAuthority(tag: String, authority: MSALAuthority) {
         let parts = authority.url.absoluteString.split(usingRegex: "https://|/")
         hostName = parts[1]
-        tenantName = parts[3]
+        if authority.url.absoluteString.contains("/tfp/") {
+            tenantName = parts[3]
+        } else {
+            tenantName = parts[2]
+        }
         print("B2CProvider [\(tag)] host: \(hostName ?? "nil"), tenant: \(tenantName ?? "nil")")
     }
     

--- a/lib/B2CConfiguration.dart
+++ b/lib/B2CConfiguration.dart
@@ -32,7 +32,7 @@ class B2CAuthority {
   late final bool isDefault;
 
   /// Return the policy name associathed to the authority.
-  String get policyName => authorityURL.split(RegExp("https://|/"))[3];
+  String get policyName => authorityURL.split(RegExp("https://|/"))[4];
 
   /// Default constructor.
   ///

--- a/lib/B2CConfiguration.dart
+++ b/lib/B2CConfiguration.dart
@@ -33,7 +33,7 @@ class B2CAuthority {
 
   /// Return the policy name associathed to the authority.
   String get policyName =>
-      (authorityURL.includes('tfp'))
+      (authorityURL.contains('tfp'))
           ? authorityURL.split(RegExp("https://|/"))[4]
           : authorityURL.split(RegExp("https://|/"))[3];
 

--- a/lib/B2CConfiguration.dart
+++ b/lib/B2CConfiguration.dart
@@ -32,7 +32,10 @@ class B2CAuthority {
   late final bool isDefault;
 
   /// Return the policy name associathed to the authority.
-  String get policyName => authorityURL.split(RegExp("https://|/"))[4];
+  String get policyName =>
+      (authorityURL.includes('tfp'))
+          ? authorityURL.split(RegExp("https://|/"))[4]
+          : authorityURL.split(RegExp("https://|/"))[3];
 
   /// Default constructor.
   ///

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_azure_b2c
 description: A flutter library to handle the Azure B2C authentication protocol
-version: 0.0.9
+version: 0.0.10
 homepage: "https://github.com/nodriver-ai/flutter_azure_b2c"
 
 environment:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_azure_b2c
 description: A flutter library to handle the Azure B2C authentication protocol
-version: 0.0.10
+version: 0.0.11
 homepage: "https://github.com/nodriver-ai/flutter_azure_b2c"
 
 environment:


### PR DESCRIPTION
To work with B2C, MSAL requires a different authority configuration. MSAL recognizes one authority URL format as B2C by itself. The recognized B2C authority format is https://<host>/tfp/<tenant>/<policy>, for example https://login.microsoftonline.com/tfp/contoso.onmicrosoft.com/B2C_1_SignInPolicy. However, you can also use any other supported B2C authority URLs by declaring authority as B2C authority explicitly.

More info can be found here
https://learn.microsoft.com/en-us/entra/msal/objc/configure-authority