### PR TITLE
Null check for users when getting subjects

### DIFF
--- a/ios/Classes/B2CProvider.swift
+++ b/ios/Classes/B2CProvider.swift
@@ -219,7 +219,7 @@ class B2CProvider {
      */
     func getSubjects() -> [String] {
         var subjects: [String] = []
-        users!.forEach { user in
+        users?.forEach { user in
             if let subject = user.subject { subjects.append(subject) }
         }
         return subjects


### PR DESCRIPTION
This will prevent the crash if we try to get subjects when there are no subjects but instead return an empty array of subjects